### PR TITLE
Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://github.com/blink1073/oct2py
 
 Package license: MIT
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Python to GNU Octave bridge --> run m-files from python
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
-{% set version = "3.5.4" %}
+{% set version = "3.5.5" %}
+{% set commit = "8ae7a710871a70e3cf4eb1c760dcb7e035f02cff" %}
 
 package:
     name: oct2py
     version: {{ version }}
 
 source:
-    fn: v{{ version }}.tar.gz
-    url: https://github.com/blink1073/oct2py/archive/v{{ version }}.tar.gz
-    sha256: 1db3911ab1d96d0618042381a0fd517ce9c6b599c1b37fe462f8caba13753924
+    fn: oct2py-{{ version }}.tar.gz
+    url: https://github.com/blink1073/oct2py/archive/{{ commit }}.tar.gz
+    sha256: f6c247ccee29a95d03710fcb754f217eddfdee08ef3f288401f115113bb17a48
 
 build:
     number: 0

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,4 @@
+try:
+    import oct2py
+except OSError as e:
+    print(e)


### PR DESCRIPTION
Not sure if this is the best way to go here, but `oct2py` does not have a source distribution at PyPI (only wheels) and no GitHub tag/release.
